### PR TITLE
Updates in "Parse then simulate" chapter

### DIFF
--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -76,6 +76,6 @@ job <- model$run(weather = epw,
 
 It is sometime useful to save the simulation output files to a temporary directory when the model is still evolving. You can achieve this by specifying `dir = tempdir()`.
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(epw, dir = tempdir())
 ```

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -74,7 +74,7 @@ job <- model$run(weather = epw,
                  dir = here("data", "idf", "run", "test_run"))
 ```
 
-If you do not want to save the simulation results locally, you can save the simulation output files to a temporary directory by specifying `dir = tempdir()`.
+It is sometime useful to save the simulation output files to a temporary directory when the model is still evolving. You can achieve this by specifying `dir = tempdir()`.
 
 ```{r}
 job <- model$run(epw, dir = tempdir())

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -71,7 +71,7 @@ You can use the `run()` method of the Idf class to run the simulation using Ener
 
 ```{r, eval = FALSE}
 job <- model$run(weather = epw,
-                 dir = here("data", "idf", "run", "test_run.idf"))
+                 dir = here("data", "idf", "run", "test_run"))
 ```
 
 If you do not want to save the simulation results locally, you can save the simulation output files to a temporary directory by specifying `dir = tempdir()`.

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -67,7 +67,7 @@ knitr::include_graphics("figures/sim_control.png")
 knitr::include_graphics("figures/run_period.png")
 ```
 
-You can use the `run()` method of the Idf class to run the simulation using EnergyPlus. You can choose the weather file to run the simulation by specifying an `Epw` object or a file path of an `.epw` file to the `weather` argument. You can also specify a directory to save the simulation results using the `dir` argument. By default, the folder of your Idf file is used to save the simulation results. 
+You can use the `run()` method of the Idf class to run the simulation using EnergyPlus. You can choose the weather file to run the simulation by specifying an `Epw` object or a file path of an `.epw` file to the `weather` argument. You can also specify a directory to save the simulation results using the `dir` argument. By default, the folder of your IDF file is used to save the simulation results. 
 
 ```{r, eval = FALSE}
 job <- model$run(weather = epw,

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -28,7 +28,7 @@ epw <- read_epw(path_epw)
 
 To output the summary reports from EnergyPlus, you need to first run the simulation. The object `job` in the code below belongs to the `EplusJob` class. If you set `dir = NULL`, the simulation results will not be saved into a temporary directory but instead in the folder containing the IDF file. Do that and you will find the summary report in a html file as illustrated in Figure \@ref(fig:tabular-data).
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(epw, dir = tempdir())
 class(job)
 ```

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-In this chapter we will focus on how to set and get EnergyPlus simulation outputs using the eplusr package. We will illustrate the manipulation of simulation data using tidyverse, and use ggplot2 to visualize the simulation data
+In this chapter we will focus on how to set and get EnergyPlus simulation outputs using the eplusr package. We will illustrate the manipulation of simulation data using {tidyverse}, and use {ggplot2} to visualize the simulation data
 
 ```{r, message=FALSE}
 library(eplusr)

--- a/13-visualize.Rmd
+++ b/13-visualize.Rmd
@@ -25,7 +25,7 @@ library(lubridate)
 
 In this chapter, you will also be working with the U.S. Department of Energy (DOE) Commercial Reference Building for medium office energy model [@deru_us_2011] and the third and latest typical meteorological (TMY3) weather data for Chicago. You will first parse the IDf and EPW to R and run the simulation to extract the simulation results.
 
-```{r, message=FALSE}
+```{r, message = FALSE, out.lines = 15}
 path_idf <- here("data", "idf", "RefBldgMediumOfficeNew2004_Chicago.idf")
 model <- read_idf(path_idf)
 

--- a/17-output.Rmd
+++ b/17-output.Rmd
@@ -28,7 +28,7 @@ epw <- read_epw(path_epw)
 The variable dictionary reports are one of the most important outputs when working with EnergyPlus simulations. These reports inform EnergyPlus users the outputs that are available for a specific EnergyPlus simulation. Knowing the outputs that are available in your model would allow users to identify and subsequently specify relevant outputs for further analysis. Two data dictionary reports are produced and they are the **m**eter **d**ata **d**ictionary (`.mdd`) file and the **r**eport **d**ata **d**ictionary (`.rdd`) file. The `.mdd` file lists the names of the output meters while the `.rdd` file lists the names of the output variables that are available for the simulation. However, you must first run the simulation before the available variables and meters can be known. By setting `weather = NULL`, a design day simulation will be run, allowing us to obtain the `.rdd` and `.mdd` file without running an annual simulation that can be time consuming for complex models. 
 
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(weather = NULL, dir = tempdir())
 ```
 
@@ -192,7 +192,7 @@ model$Output_Meter
 
 Before you can explore the outputs, you have to first save the model and run the simulation. 
 
-```{r}
+```{r, out.lines = 15}
 model$save(here("data", "idf", "model_preprocessed.idf"), overwrite = TRUE)
 job <- model$run(epw, dir = tempdir())
 ```

--- a/18-explore.Rmd
+++ b/18-explore.Rmd
@@ -96,7 +96,7 @@ model <- preprocess_idf(model, meters, variables)
 
 You can then run the simulation and it will be possible to extract the output of interest from the model.
 
-```{r}
+```{r, out.lines = 15}
 model$save(here("data", "idf", "model_preprocessed.idf"), overwrite = TRUE)
 job <- model$run(epw, dir = tempdir())
 ```


### PR DESCRIPTION
### Pull request overview

- Change simulation output directory:
  - from `here("data", "idf", "run", "test_run.idf")` 
  - to `here("data", "idf", "run", "test_run")`
- Use "IDF" instead of "Idf" when referring to a file
- Change the reason why using `dir = tempdir()`. Because "locally" is not precise here, since the simulation output are still saved on the user local computer.
- Truncate EnergyPlus simulation messages from `EplusJob$run()` to 15 lines.