### PR TITLE
Fix long output truncation issue

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -40,7 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Build site
-        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE)'
+        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = FALSE)'
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -40,7 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Build site
-        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = FALSE)'
+        run: Rscript -e 'bookdown::render_book("index.Rmd", quiet = TRUE)'
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -4,30 +4,29 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    branches: [main, master]
 
 name: bookdown
 
 jobs:
   bookdown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
-      RENV_CONFIG_REPOS_OVERRIDE: "https://packagemanager.rstudio.com/cran/latest"
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
       - name: Install system dependencies
         run: sudo apt-get install -y libudunits2-dev
 
-      - uses: r-lib/actions/setup-renv@v1
+      - uses: r-lib/actions/setup-renv@v2
 
       - name: Cache bookdown results
         uses: actions/cache@v2

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -1,5 +1,8 @@
 # (PART) R Basics {-}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 # Introduction {#r-basics}
 
 This part of the book is intended to provide a sufficient introduction to R to get you started on the subsequent parts of this book. For a more comprehensive treatment on the subject, I would recommend [R for Data Science](https://r4ds.had.co.nz/index.html) by Hadley Wickham & Garrett Grolemund [@wickham_r_2016]. The [R Graphics Cookbook](https://r-graphics.org) by Winston Chang [@chang_r_2018] is also a useful reference that provides recipes that allows you to quickly generate plots in R using the ggplot2 package. 

--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -1,6 +1,7 @@
 # (PART) R Basics {-}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 # Introduction {#r-basics}

--- a/02-rbasics.Rmd
+++ b/02-rbasics.Rmd
@@ -1,5 +1,8 @@
 # Basics
 
+```{r, file='_common.R', include=FALSE}
+```
+
 ## Prerequisites
 
 We introduce the basics in R programming in this chapter. We will review the basic operators and data types in this chapter. We also provide an introduction to the basic R data structures (including tibbles and data tables).

--- a/02-rbasics.Rmd
+++ b/02-rbasics.Rmd
@@ -1,6 +1,7 @@
 # Basics
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/03-date.Rmd
+++ b/03-date.Rmd
@@ -1,5 +1,7 @@
-
 # Dates and Times {#datetime}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/03-date.Rmd
+++ b/03-date.Rmd
@@ -1,6 +1,7 @@
 # Dates and Times {#datetime}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/04-import.Rmd
+++ b/04-import.Rmd
@@ -1,6 +1,7 @@
 # Importing Data
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/04-import.Rmd
+++ b/04-import.Rmd
@@ -1,5 +1,8 @@
 # Importing Data
 
+```{r, file='_common.R', include=FALSE}
+```
+
 ## Prerequisites
 
 In this chapter, we focus on the use of the **{readr}** package that forms a part of the **{tidyverse}** package. **{readr}** provides a fast and easy way to parse a file because it uses a sophisticated parser that guesses the data type for each column along with the flexibility to specify what to parse. You will also need  the **{here}** package (to easily provide relative file paths) and the **{lubridate}** package (to work with dates and times). 

--- a/05-regex.Rmd
+++ b/05-regex.Rmd
@@ -1,5 +1,8 @@
 # Regular expressions {#regex}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 *Regular expressions* are patterns that are used to match combinations of characters in a string. Before we begin, just a cautionary note that if your regular expressions are becoming too complex, perhaps it is time to step back and think about whether it is necessary and if they can be represented multiple expressions that are easier to understand. 
 
 ## Prerequisites

--- a/05-regex.Rmd
+++ b/05-regex.Rmd
@@ -1,6 +1,7 @@
 # Regular expressions {#regex}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 *Regular expressions* are patterns that are used to match combinations of characters in a string. Before we begin, just a cautionary note that if your regular expressions are becoming too complex, perhaps it is time to step back and think about whether it is necessary and if they can be represented multiple expressions that are easier to understand. 

--- a/06-functions.Rmd
+++ b/06-functions.Rmd
@@ -1,6 +1,7 @@
 # Functions
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 Writing functions is a simple way to automate commonly used code in a more general way. Therefore, you should write a function when you realized that you are copying and pasting a code block more than once. Particularly, you will see the power of functions as we start writing functions to define building energy efficient measures that we wish to apply to the building energy simulation. 

--- a/06-functions.Rmd
+++ b/06-functions.Rmd
@@ -1,5 +1,8 @@
 # Functions
 
+```{r, file='_common.R', include=FALSE}
+```
+
 Writing functions is a simple way to automate commonly used code in a more general way. Therefore, you should write a function when you realized that you are copying and pasting a code block more than once. Particularly, you will see the power of functions as we start writing functions to define building energy efficient measures that we wish to apply to the building energy simulation. 
 
 Additionally, using functions helps you to avoid making mistakes that happen all too often when copying and pasting code. Additionally, as your requirements change, you only need to update the code in one place (i.e., within the function) instead of searching and updating pieces of code, which is again error-prone. 

--- a/07-manipulate.Rmd
+++ b/07-manipulate.Rmd
@@ -1,6 +1,7 @@
 # Manipulating Data {#manipulate}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 Data-preprocessing is an important step in any data science process. Rarely will you receive data that is in the exact form that you need. More often than not, you would need to pre-process the data by transforming and manipulating them so that they are easier to work with. This will be the focus in this chapter.

--- a/07-manipulate.Rmd
+++ b/07-manipulate.Rmd
@@ -1,5 +1,7 @@
-
 # Manipulating Data {#manipulate}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 Data-preprocessing is an important step in any data science process. Rarely will you receive data that is in the exact form that you need. More often than not, you would need to pre-process the data by transforming and manipulating them so that they are easier to work with. This will be the focus in this chapter.
 

--- a/10-start-intro.Rmd
+++ b/10-start-intro.Rmd
@@ -1,6 +1,7 @@
 # (PART) Get Started {-}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 # Introduction {#get-started}

--- a/10-start-intro.Rmd
+++ b/10-start-intro.Rmd
@@ -1,5 +1,8 @@
 # (PART) Get Started {-}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 # Introduction {#get-started}
 
 The goal of this part of the book is to get you started working with EnergyPlus in R as quickly as possible. In this part of the book, you will learn how to get your model into R and run the simulation (Chapter \@ref(parse)). You will then learn how to  extract predifined annual summary reports and manipulate them so that the focus is placed on the important variables and observations (Chapter \@ref(summary)). Finally, we provide a gentle introduction to visualizing the data from the summary reports in R (Chapter \@ref(visualize)).

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -76,6 +76,6 @@ job <- model$run(weather = epw,
 
 It is sometime useful to save the simulation output files to a temporary directory when the model is still evolving. You can achieve this by specifying `dir = tempdir()`.
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(epw, dir = tempdir())
 ```

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -74,7 +74,7 @@ job <- model$run(weather = epw,
                  dir = here("data", "idf", "run", "test_run"))
 ```
 
-If you do not want to save the simulation results locally, you can save the simulation output files to a temporary directory by specifying `dir = tempdir()`.
+It is sometime useful to save the simulation output files to a temporary directory when the model is still evolving. You can achieve this by specifying `dir = tempdir()`.
 
 ```{r}
 job <- model$run(epw, dir = tempdir())

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -71,7 +71,7 @@ You can use the `run()` method of the Idf class to run the simulation using Ener
 
 ```{r, eval = FALSE}
 job <- model$run(weather = epw,
-                 dir = here("data", "idf", "run", "test_run.idf"))
+                 dir = here("data", "idf", "run", "test_run"))
 ```
 
 If you do not want to save the simulation results locally, you can save the simulation output files to a temporary directory by specifying `dir = tempdir()`.

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -1,6 +1,7 @@
 # Parse then simulate {#parse}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -67,7 +67,7 @@ knitr::include_graphics("figures/sim_control.png")
 knitr::include_graphics("figures/run_period.png")
 ```
 
-You can use the `run()` method of the Idf class to run the simulation using EnergyPlus. You can choose the weather file to run the simulation by specifying an `Epw` object or a file path of an `.epw` file to the `weather` argument. You can also specify a directory to save the simulation results using the `dir` argument. By default, the folder of your Idf file is used to save the simulation results. 
+You can use the `run()` method of the Idf class to run the simulation using EnergyPlus. You can choose the weather file to run the simulation by specifying an `Epw` object or a file path of an `.epw` file to the `weather` argument. You can also specify a directory to save the simulation results using the `dir` argument. By default, the folder of your IDF file is used to save the simulation results. 
 
 ```{r, eval = FALSE}
 job <- model$run(weather = epw,

--- a/11-parse.Rmd
+++ b/11-parse.Rmd
@@ -1,5 +1,7 @@
-
 # Parse then simulate {#parse}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -1,6 +1,7 @@
 # Summary reports {#summary}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -28,7 +28,7 @@ epw <- read_epw(path_epw)
 
 To output the summary reports from EnergyPlus, you need to first run the simulation. The object `job` in the code below belongs to the `EplusJob` class. If you set `dir = NULL`, the simulation results will not be saved into a temporary directory but instead in the folder containing the IDF file. Do that and you will find the summary report in a html file as illustrated in Figure \@ref(fig:tabular-data).
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(epw, dir = tempdir())
 class(job)
 ```

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -1,5 +1,7 @@
-
 # Summary reports {#summary}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/12-summary.Rmd
+++ b/12-summary.Rmd
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-In this chapter we will focus on how to set and get EnergyPlus simulation outputs using the eplusr package. We will illustrate the manipulation of simulation data using tidyverse, and use ggplot2 to visualize the simulation data
+In this chapter we will focus on how to set and get EnergyPlus simulation outputs using the eplusr package. We will illustrate the manipulation of simulation data using {tidyverse}, and use {ggplot2} to visualize the simulation data
 
 ```{r, message=FALSE}
 library(eplusr)

--- a/13-visualize.Rmd
+++ b/13-visualize.Rmd
@@ -1,6 +1,7 @@
 # Visualize {#visualize}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/13-visualize.Rmd
+++ b/13-visualize.Rmd
@@ -25,7 +25,7 @@ library(lubridate)
 
 In this chapter, you will also be working with the U.S. Department of Energy (DOE) Commercial Reference Building for medium office energy model [@deru_us_2011] and the third and latest typical meteorological (TMY3) weather data for Chicago. You will first parse the IDf and EPW to R and run the simulation to extract the simulation results.
 
-```{r, message=FALSE}
+```{r, message = FALSE, out.lines = 15}
 path_idf <- here("data", "idf", "RefBldgMediumOfficeNew2004_Chicago.idf")
 model <- read_idf(path_idf)
 

--- a/13-visualize.Rmd
+++ b/13-visualize.Rmd
@@ -1,5 +1,7 @@
-
 # Visualize {#visualize}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/14-input-intro.Rmd
+++ b/14-input-intro.Rmd
@@ -1,6 +1,7 @@
 # (PART) Inputs and Outputs {-}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 # Introduction {#input-output}

--- a/14-input-intro.Rmd
+++ b/14-input-intro.Rmd
@@ -1,5 +1,8 @@
 # (PART) Inputs and Outputs {-}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 # Introduction {#input-output}
 
 In this part of the book, you will learn EnergyPlus's input data structure (Chapter \@ref(input)), and how to programmatically query and modify them in R (Chapter \@ref(modify)). We will also point you to the corresponding EnergyPlus reference documentation that will help you gain a better understanding of the inner workings of EnergyPlus. Understanding the inputs to a model is important as the proverb "garbage in, garbage out" clearly spells out. You can have the best data science workflows but your simulation results would only be as good the quality of your model and it's inputs. 

--- a/15-input.Rmd
+++ b/15-input.Rmd
@@ -1,5 +1,7 @@
-
 # Model Input Structure {#input}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/15-input.Rmd
+++ b/15-input.Rmd
@@ -1,6 +1,7 @@
 # Model Input Structure {#input}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/16-modify.Rmd
+++ b/16-modify.Rmd
@@ -1,5 +1,8 @@
 # Modify model inputs {#modify}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 In this chapter, you will learn how modify the model inputs.
 
 ## Prerequisites

--- a/16-modify.Rmd
+++ b/16-modify.Rmd
@@ -1,6 +1,7 @@
 # Modify model inputs {#modify}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 In this chapter, you will learn how modify the model inputs.

--- a/17-output.Rmd
+++ b/17-output.Rmd
@@ -1,6 +1,7 @@
 # Detailed output {#output}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/17-output.Rmd
+++ b/17-output.Rmd
@@ -1,5 +1,7 @@
-
 # Detailed output {#output}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/17-output.Rmd
+++ b/17-output.Rmd
@@ -28,7 +28,7 @@ epw <- read_epw(path_epw)
 The variable dictionary reports are one of the most important outputs when working with EnergyPlus simulations. These reports inform EnergyPlus users the outputs that are available for a specific EnergyPlus simulation. Knowing the outputs that are available in your model would allow users to identify and subsequently specify relevant outputs for further analysis. Two data dictionary reports are produced and they are the **m**eter **d**ata **d**ictionary (`.mdd`) file and the **r**eport **d**ata **d**ictionary (`.rdd`) file. The `.mdd` file lists the names of the output meters while the `.rdd` file lists the names of the output variables that are available for the simulation. However, you must first run the simulation before the available variables and meters can be known. By setting `weather = NULL`, a design day simulation will be run, allowing us to obtain the `.rdd` and `.mdd` file without running an annual simulation that can be time consuming for complex models. 
 
 
-```{r}
+```{r, out.lines = 15}
 job <- model$run(weather = NULL, dir = tempdir())
 ```
 
@@ -192,7 +192,7 @@ model$Output_Meter
 
 Before you can explore the outputs, you have to first save the model and run the simulation. 
 
-```{r}
+```{r, out.lines = 15}
 model$save(here("data", "idf", "model_preprocessed.idf"), overwrite = TRUE)
 job <- model$run(epw, dir = tempdir())
 ```

--- a/18-explore.Rmd
+++ b/18-explore.Rmd
@@ -96,7 +96,7 @@ model <- preprocess_idf(model, meters, variables)
 
 You can then run the simulation and it will be possible to extract the output of interest from the model.
 
-```{r}
+```{r, out.lines = 15}
 model$save(here("data", "idf", "model_preprocessed.idf"), overwrite = TRUE)
 job <- model$run(epw, dir = tempdir())
 ```

--- a/18-explore.Rmd
+++ b/18-explore.Rmd
@@ -1,6 +1,7 @@
 # Model Exploration {#explore}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/18-explore.Rmd
+++ b/18-explore.Rmd
@@ -1,5 +1,7 @@
-
 # Model Exploration {#explore}
+
+```{r, file='_common.R', include=FALSE}
+```
 
 ## Prerequisites
 

--- a/22-program.Rmd
+++ b/22-program.Rmd
@@ -2,5 +2,6 @@
 
 # Introduction {#program}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```

--- a/22-program.Rmd
+++ b/22-program.Rmd
@@ -2,3 +2,5 @@
 
 # Introduction {#program}
 
+```{r, file='_common.R', include=FALSE}
+```

--- a/23-measures.Rmd
+++ b/23-measures.Rmd
@@ -1,4 +1,4 @@
-
-
 # Energy Efficient Measures
 
+```{r, file='_common.R', include=FALSE}
+```

--- a/23-measures.Rmd
+++ b/23-measures.Rmd
@@ -1,4 +1,5 @@
 # Energy Efficient Measures
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```

--- a/24-parametric.Rmd
+++ b/24-parametric.Rmd
@@ -1,4 +1,5 @@
 # Parametric simulations
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```

--- a/24-parametric.Rmd
+++ b/24-parametric.Rmd
@@ -1,3 +1,4 @@
-
 # Parametric simulations
 
+```{r, file='_common.R', include=FALSE}
+```

--- a/30-advance.Rmd
+++ b/30-advance.Rmd
@@ -2,7 +2,8 @@
 
 # Introduction {#advanced}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 # Sensitivity analysis

--- a/30-advance.Rmd
+++ b/30-advance.Rmd
@@ -2,6 +2,9 @@
 
 # Introduction {#advanced}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 # Sensitivity analysis
 
 William of Occam to seek an economical description of natural phenomena and avoid excessive models that are overparameterized. Principal of Parisimony. 

--- a/40-reproduce.Rmd
+++ b/40-reproduce.Rmd
@@ -2,6 +2,9 @@
 
 # Introduction {#reproduce}
 
+```{r, file='_common.R', include=FALSE}
+```
+
 ## Prerequisites
 
 In this chapter we will introduce concepts of reproducibility.

--- a/40-reproduce.Rmd
+++ b/40-reproduce.Rmd
@@ -2,7 +2,8 @@
 
 # Introduction {#reproduce}
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 ## Prerequisites

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,5 +1,5 @@
 book_filename: "r4bes"
-before_chapter_script: _common.R
+before_chapter_script: "_common.R"
 new_session: yes
 delete_merged_file: true
 language:

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,4 +1,5 @@
 book_filename: "r4bes"
+before_chapter_script: _common.R
 delete_merged_file: true
 language:
   ui:

--- a/_common.R
+++ b/_common.R
@@ -1,0 +1,18 @@
+# save the built-in output hook
+hook_output <- knitr::knit_hooks$get("output")
+
+# set a new output hook to truncate text output
+knitr::knit_hooks$set(output = function(x, options) {
+  if (!is.null(n <- options$out.lines)) {
+    x <- xfun::split_lines(x)
+    if (length(x) > n) {
+      # truncate the output
+      x <- c(head(x, n), "....\n")
+    }
+    x <- paste(x, collapse = "\n")
+  }
+  hook_output(x, options)
+})
+
+# set default output lines to 10
+knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, tidy = TRUE, out.lines = 10)

--- a/index.Rmd
+++ b/index.Rmd
@@ -23,6 +23,7 @@ knitr::knit_hooks$set(output = function(x, options) {
   if (!is.null(n <- options$out.lines)) {
     x <- xfun::split_lines(x)
     if (length(x) > n) {
+      cat(x)
       # truncate the output
       x <- c(head(x, n), "....\n")
     }

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,29 +14,6 @@ always_allow_html: true
 description: "A guide to the building energy simulation with R."
 ---
 
-```{r setup, include=FALSE}
-# save the built-in output hook
-hook_output <- knitr::knit_hooks$get("output")
-
-# set a new output hook to truncate text output
-knitr::knit_hooks$set(output = function(x, options) {
-  if (!is.null(n <- options$out.lines)) {
-    x <- xfun::split_lines(x)
-    if (length(x) > n) {
-      # truncate the output
-      x <- c(head(x, n), "....\n")
-    }
-    x <- paste(x, collapse = "\n")
-  }
-  hook_output(x, options)
-})
-
-knitr::opts_chunk$set(
-  echo = TRUE, collapse = TRUE,
-  out.lines = 10
-)
-```
-
 # Preface {-}
 
 ## Introduction {-}

--- a/index.Rmd
+++ b/index.Rmd
@@ -218,7 +218,7 @@ knitr::include_graphics("figures/line_length.png")
 
 <!-- To compile this example to PDF, you need XeLaTeX. You are recommended to install TinyTeX (which includes XeLaTeX): <https://yihui.org/tinytex/>. -->
 
-```{r include=FALSE, eval=FALSE}
+```{r include=FALSE}
 # automatically create a bib database for R packages
 knitr::write_bib(c(
   .packages(), "bookdown", "knitr", "rmarkdown"

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,6 +14,9 @@ always_allow_html: true
 description: "A guide to the building energy simulation with R."
 ---
 
+```{r, file='_common.R', include=FALSE}
+```
+
 # Preface {-}
 
 ## Introduction {-}

--- a/index.Rmd
+++ b/index.Rmd
@@ -21,11 +21,17 @@ hook_output <- knitr::knit_hooks$get("output")
 # set a new output hook to truncate text output
 knitr::knit_hooks$set(output = function(x, options) {
   if (!is.null(n <- options$out.lines)) {
+    cat("Required output lines: ", n, "\n")
     x <- xfun::split_lines(x)
+    cat("Number of lines after split", length(x), "\n")
     if (length(x) > n) {
+      cat("Contents after split:\n")
       cat(x)
       # truncate the output
       x <- c(head(x, n), "....\n")
+    } else {
+      cat("Contents after split:\n")
+      cat(x)
     }
     x <- paste(x, collapse = "\n")
   }

--- a/index.Rmd
+++ b/index.Rmd
@@ -23,7 +23,6 @@ knitr::knit_hooks$set(output = function(x, options) {
   if (!is.null(n <- options$out.lines)) {
     x <- xfun::split_lines(x)
     if (length(x) > n) {
-      cat(x)
       # truncate the output
       x <- c(head(x, n), "....\n")
     }

--- a/index.Rmd
+++ b/index.Rmd
@@ -21,17 +21,11 @@ hook_output <- knitr::knit_hooks$get("output")
 # set a new output hook to truncate text output
 knitr::knit_hooks$set(output = function(x, options) {
   if (!is.null(n <- options$out.lines)) {
-    cat("Required output lines: ", n, "\n")
     x <- xfun::split_lines(x)
-    cat("Number of lines after split", length(x), "\n")
     if (length(x) > n) {
-      cat("Contents after split:\n")
       cat(x)
       # truncate the output
       x <- c(head(x, n), "....\n")
-    } else {
-      cat("Contents after split:\n")
-      cat(x)
     }
     x <- paste(x, collapse = "\n")
   }

--- a/index.Rmd
+++ b/index.Rmd
@@ -14,7 +14,8 @@ always_allow_html: true
 description: "A guide to the building energy simulation with R."
 ---
 
-```{r, file='_common.R', include=FALSE}
+```{r, include=FALSE}
+source("_common.R", local = knitr::knit_global())
 ```
 
 # Preface {-}
@@ -217,7 +218,7 @@ knitr::include_graphics("figures/line_length.png")
 
 <!-- To compile this example to PDF, you need XeLaTeX. You are recommended to install TinyTeX (which includes XeLaTeX): <https://yihui.org/tinytex/>. -->
 
-```{r include=FALSE}
+```{r include=FALSE, eval=FALSE}
 # automatically create a bib database for R packages
 knitr::write_bib(c(
   .packages(), "bookdown", "knitr", "rmarkdown"


### PR DESCRIPTION
This issue came from how the knit-merge rendering approach in bookdown and how the `before_chapter_script ` works when `new_session ` is set to true, see: https://github.com/rstudio/bookdown/issues/1252. 

We did not notice this issue because `bookdown::serve_book()` uses merge-knit rendering approach which makes the `setup` chunk in `index.Rmd` affects all other Rmd files.

I believe we should keep the `new_session` to `true` to make code for every Rmd file isolated. In this PR, I use the approach described here: https://github.com/rstudio/bookdown/issues/1252#issuecomment-913530117. I.e. sourcing the setup chunk for every Rmd.