### PR TITLE
Directly subset report data using `name` and extract wide table using `wide`

### DIFF
--- a/15-output.Rmd
+++ b/15-output.Rmd
@@ -237,10 +237,11 @@ You will then be able to extract the output variables and meters that have just
 been specified.
 
 ```{r}
-report <- job$report_data(environment_name = "annual") %>%
-    drop_na() %>%
+report <- job$report_data(
+        name = c(variables$Variable_Name, meters$key_name),
+        environment_name = "annual"
+    ) %>%
     select(datetime, name, value) %>%
-    filter(name %in% variables$Variable_Name | name %in% meters$key_name) %>%
     pivot_wider(names_from = name, values_from = value)
 
 head(report)

--- a/16-explore.Rmd
+++ b/16-explore.Rmd
@@ -121,7 +121,10 @@ pt_of_interest <- c(
     "Heating:NaturalGas"
 )
 
-report <- job$report_data(environment_name = "annual") %>%
+report <- job$report_data(
+    name = pt_of_interest,
+    environment_name = "annual"
+    ) %>%
     drop_na() %>%
     select(datetime, name, value) %>%
     filter(name %in% pt_of_interest) %>%

--- a/16-explore.Rmd
+++ b/16-explore.Rmd
@@ -122,24 +122,19 @@ pt_of_interest <- c(
 )
 
 report <- job$report_data(
-    name = pt_of_interest,
-    environment_name = "annual"
+        name = pt_of_interest, environment_name = "annual",
+        all = TRUE, wide = TRUE
     ) %>%
-    drop_na() %>%
-    select(datetime, name, value) %>%
-    filter(name %in% pt_of_interest) %>%
-    pivot_wider(names_from = name, values_from = value) %>%
+    select(datetime, month, day, hour, day_type, contains(pt_of_interest)) %>%
+    rename_with(~pt_of_interest, .cols = contains(pt_of_interest)) %>%
     pivot_longer(
         cols = c("Cooling:Electricity", "Heating:NaturalGas"),
         names_to = "type", values_to = "value"
     ) %>%
     mutate(
         value = value * 1e-6, # convert J to MJ
-        month = month(datetime, label = TRUE), # create a new column containing the month
-        day = day(datetime), # create a new column containing the day of the month
-        wday = wday(datetime, label = TRUE), # create a new column containing day of the week
-        hour = hour(datetime)
-    ) # create a new column containing the hour of the day
+        month = ordered(month.abb[month], month.abb) # replace month index with month name
+    )
 ```
 
 ```{r}


### PR DESCRIPTION
### Pull request overview

- Fixes #13
- By default, `EplusJob$report_data()` will extract all simulation output variables and meters. It will be more efficient to first subset the data using the `name` input, instead of extracting all data into memory and filtering using `dplyr::filter()`.
- `EplusJob$report_data()` with `all = TRUE` will include all date-time components, including `month`, `day`, `hour`, `minute`, `day_type` (e.g. `Monday` - `Sunday`, `Holiday` etc.) It's good to directly take advantage of those values generated from EnergyPlus itself, instead of manually creating them. This makes the data comply with EnergyPlus, especially for the `hour` where EnergyPlus uses 1-24 notation.
- `EplusJob$report_data()` with `wide = TRUE` will format the data into a "wide" table in the almost same way as EnergyPlus csv output.